### PR TITLE
batches: update k8s manifest in repos (demo)

### DIFF
--- a/volumes/iscsi/chap-secret.yaml
+++ b/volumes/iscsi/chap-secret.yaml
@@ -1,15 +1,17 @@
----
 apiVersion: v1
+data:
+  discovery.sendtargets.auth.password: ZGVtbw==
+  discovery.sendtargets.auth.password_in: bXBhc3M=
+  discovery.sendtargets.auth.username: dXNlcg==
+  discovery.sendtargets.auth.username_in: bXVzZXI=
+  node.session.auth.password: cGFzc3dvcmQ=
+  node.session.auth.password_in: bXBhc3My
+  node.session.auth.username: dXNlcm5hbWU=
+  node.session.auth.username_in: bXVzZXIy
 kind: Secret
 metadata:
+  annotations:
+    my-key: my-value
   name: chap-secret
-type: "kubernetes.io/iscsi-chap"
-data:
-  discovery.sendtargets.auth.username: dXNlcg==
-  discovery.sendtargets.auth.password: ZGVtbw==
-  discovery.sendtargets.auth.username_in: bXVzZXI=
-  discovery.sendtargets.auth.password_in: bXBhc3M=
-  node.session.auth.username: dXNlcm5hbWU=
-  node.session.auth.password: cGFzc3dvcmQ=
-  node.session.auth.username_in: bXVzZXIy
-  node.session.auth.password_in: bXBhc3My
+  namespace: my-namespace
+type: kubernetes.io/iscsi-chap

--- a/volumes/iscsi/iscsi-chap.yaml
+++ b/volumes/iscsi/iscsi-chap.yaml
@@ -1,24 +1,26 @@
----
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    my-key: my-value
   name: iscsipd
+  namespace: my-namespace
 spec:
   containers:
-  - name: iscsipd-ro
-    image: kubernetes/pause
+  - image: kubernetes/pause
+    name: iscsipd-ro
     volumeMounts:
-    - mountPath: "/mnt/iscsipd"
+    - mountPath: /mnt/iscsipd
       name: iscsivol
   volumes:
-  - name: iscsivol
-    iscsi:
-      targetPortal: 127.0.0.1
-      iqn: iqn.2015-02.example.com:test
-      lun: 0
-      fsType: ext4
-      readOnly: true
+  - iscsi:
       chapAuthDiscovery: true
       chapAuthSession: true
+      fsType: ext4
+      iqn: iqn.2015-02.example.com:test
+      lun: 0
+      readOnly: true
       secretRef:
-         name: chap-secret
+        name: chap-secret
+      targetPortal: 127.0.0.1
+    name: iscsivol

--- a/volumes/iscsi/iscsi.yaml
+++ b/volumes/iscsi/iscsi.yaml
@@ -1,21 +1,25 @@
----
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    my-key: my-value
   name: iscsipd
+  namespace: my-namespace
 spec:
   containers:
-  - name: iscsipd-rw
-    image: kubernetes/pause
+  - image: kubernetes/pause
+    name: iscsipd-rw
     volumeMounts:
-    - mountPath: "/mnt/iscsipd"
+    - mountPath: /mnt/iscsipd
       name: iscsipd-rw
   volumes:
-  - name: iscsipd-rw
-    iscsi:
-      targetPortal: 10.0.2.15:3260
-      portals: ['10.0.2.16:3260', '10.0.2.17:3260']
+  - iscsi:
+      fsType: ext4
       iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
       lun: 0
-      fsType: ext4
+      portals:
+      - 10.0.2.16:3260
+      - 10.0.2.17:3260
       readOnly: true
+      targetPortal: 10.0.2.15:3260
+    name: iscsipd-rw


### PR DESCRIPTION
Not my first batch change.

Add namespace and modify metadata annotations.

This is an arbitrary script used to insert some made up values that Bolaji created into
kubernetes spec files. 
The script doesn't explicitly check which YAML is used by k8s because it assumes every YAML
in the `sourcegraph-testing/k8s-examples` repo is a kubernetes spec file.





  #### Modified Files
  
    - cassandra/cassandra-service.yaml

  
    - cassandra/cassandra-statefulset.yaml

  
    - cassandra/image/files/cassandra.yaml

  
    - cassandra/java/src/test/resources/cassandra.yaml

  
    - dev/cloudbuild/cloudbuild.yaml

  
    - guestbook-go/guestbook-controller.yaml

  
    - guestbook-go/guestbook-service.yaml

  
    - guestbook-go/redis-master-controller.yaml

  
    - guestbook-go/redis-master-service.yaml

  
    - guestbook-go/redis-replica-controller.yaml

  
    - guestbook-go/redis-replica-service.yaml

  
    - guestbook/all-in-one/frontend.yaml

  
    - guestbook/all-in-one/guestbook-all-in-one.yaml

  
    - guestbook/all-in-one/redis-replica.yaml

  
    - guestbook/frontend-deployment.yaml

  
    - guestbook/frontend-service.yaml

  
    - guestbook/legacy/frontend-controller.yaml

  
    - guestbook/legacy/redis-master-controller.yaml

  
    - guestbook/legacy/redis-replica-controller.yaml

  
    - guestbook/redis-master-deployment.yaml

  
    - guestbook/redis-master-service.yaml

  
    - guestbook/redis-replica-deployment.yaml

  
    - guestbook/redis-replica-service.yaml

  
    - mysql-cinder-pd/mysql-service.yaml

  
    - mysql-cinder-pd/mysql.yaml

  
    - mysql-wordpress-pd/gce-volumes.yaml

  
    - mysql-wordpress-pd/local-volumes.yaml

  
    - mysql-wordpress-pd/mysql-deployment.yaml

  
    - mysql-wordpress-pd/wordpress-deployment.yaml

  
    - staging/cloud-controller-manager/persistent-volume-label-initializer-config.yaml

  
    - staging/cluster-dns/dns-backend-rc.yaml

  
    - staging/cluster-dns/dns-backend-service.yaml

  
    - staging/cluster-dns/dns-frontend-pod.yaml

  
    - staging/cluster-dns/namespace-dev.yaml

  
    - staging/cluster-dns/namespace-prod.yaml

  
    - staging/cockroachdb/cockroachdb-statefulset.yaml

  
    - staging/cpu-manager/be.yaml

  
    - staging/cpu-manager/exclusive-1.yaml

  
    - staging/cpu-manager/exclusive-2.yaml

  
    - staging/cpu-manager/exclusive-3.yaml

  
    - staging/cpu-manager/exclusive-4.yaml

  
    - staging/cpu-manager/shared.yaml

  
    - staging/elasticsearch/es-rc.yaml

  
    - staging/elasticsearch/es-svc.yaml

  
    - staging/elasticsearch/production_cluster/es-client-rc.yaml

  
    - staging/elasticsearch/production_cluster/es-data-rc.yaml

  
    - staging/elasticsearch/production_cluster/es-discovery-svc.yaml

  
    - staging/elasticsearch/production_cluster/es-master-rc.yaml

  
    - staging/elasticsearch/production_cluster/es-svc.yaml

  
    - staging/elasticsearch/production_cluster/service-account.yaml

  
    - staging/elasticsearch/rbac.yaml

  
    - staging/elasticsearch/service-account.yaml

  
    - staging/explorer/pod.yaml

  
    - staging/https-nginx/nginx-app.yaml

  
    - staging/javaee/mysql-pod.yaml

  
    - staging/javaee/mysql-service.yaml

  
    - staging/javaee/wildfly-rc.yaml

  
    - staging/javaweb-tomcat-sidecar/javaweb-2.yaml

  
    - staging/javaweb-tomcat-sidecar/javaweb.yaml

  
    - staging/nodesjs-mongodb/mongo-controller.yaml

  
    - staging/nodesjs-mongodb/mongo-service.yaml

  
    - staging/nodesjs-mongodb/web-controller-demo.yaml

  
    - staging/nodesjs-mongodb/web-controller.yaml

  
    - staging/nodesjs-mongodb/web-service.yaml

  
    - staging/openshift-origin/etcd-controller.yaml

  
    - staging/openshift-origin/etcd-discovery-controller.yaml

  
    - staging/openshift-origin/etcd-discovery-service.yaml

  
    - staging/openshift-origin/etcd-service.yaml

  
    - staging/openshift-origin/openshift-controller.yaml

  
    - staging/openshift-origin/openshift-origin-namespace.yaml

  
    - staging/openshift-origin/openshift-service.yaml

  
    - staging/persistent-volume-provisioning/aws-ebs.yaml

  
    - staging/persistent-volume-provisioning/cinder/cinder-storage-class.yaml

  
    - staging/persistent-volume-provisioning/cinder/example-pod.yaml

  
    - staging/persistent-volume-provisioning/gce-pd.yaml

  
    - staging/persistent-volume-provisioning/glusterfs/glusterfs-secret.yaml

  
    - staging/persistent-volume-provisioning/glusterfs/glusterfs-storageclass.yaml

  
    - staging/persistent-volume-provisioning/quobyte/example-pod.yaml

  
    - staging/persistent-volume-provisioning/quobyte/quobyte-admin-secret.yaml

  
    - staging/persistent-volume-provisioning/quobyte/quobyte-storage-class.yaml

  
    - staging/persistent-volume-provisioning/rbd/ceph-secret-admin.yaml

  
    - staging/persistent-volume-provisioning/rbd/ceph-secret-user.yaml

  
    - staging/persistent-volume-provisioning/rbd/pod.yaml

  
    - staging/persistent-volume-provisioning/rbd/rbd-storage-class.yaml

  
    - staging/podsecuritypolicy/rbac/bindings.yaml

  
    - staging/podsecuritypolicy/rbac/pod.yaml

  
    - staging/podsecuritypolicy/rbac/pod_priv.yaml

  
    - staging/podsecuritypolicy/rbac/policies.yaml

  
    - staging/podsecuritypolicy/rbac/roles.yaml

  
    - staging/selenium/selenium-hub-deployment.yaml

  
    - staging/selenium/selenium-hub-svc.yaml

  
    - staging/selenium/selenium-node-chrome-deployment.yaml

  
    - staging/selenium/selenium-node-firefox-deployment.yaml

  
    - staging/spark/namespace-spark-cluster.yaml

  
    - staging/spark/spark-gluster/glusterfs-endpoints.yaml

  
    - staging/spark/spark-gluster/spark-master-controller.yaml

  
    - staging/spark/spark-gluster/spark-master-service.yaml

  
    - staging/spark/spark-gluster/spark-worker-controller.yaml

  
    - staging/spark/spark-master-controller.yaml

  
    - staging/spark/spark-master-service.yaml

  
    - staging/spark/spark-ui-proxy-controller.yaml

  
    - staging/spark/spark-ui-proxy-service.yaml

  
    - staging/spark/spark-worker-controller.yaml

  
    - staging/spark/zeppelin-controller.yaml

  
    - staging/spark/zeppelin-service.yaml

  
    - staging/storage/hazelcast/hazelcast-deployment.yaml

  
    - staging/storage/hazelcast/hazelcast-service.yaml

  
    - staging/storage/minio/minio-distributed-headless-service.yaml

  
    - staging/storage/minio/minio-distributed-service.yaml

  
    - staging/storage/minio/minio-distributed-statefulset.yaml

  
    - staging/storage/minio/minio-standalone-deployment.yaml

  
    - staging/storage/minio/minio-standalone-pvc.yaml

  
    - staging/storage/minio/minio-standalone-service.yaml

  
    - staging/storage/mysql-galera/pxc-cluster-service.yaml

  
    - staging/storage/mysql-galera/pxc-node1.yaml

  
    - staging/storage/mysql-galera/pxc-node2.yaml

  
    - staging/storage/mysql-galera/pxc-node3.yaml

  
    - staging/storage/redis/redis-controller.yaml

  
    - staging/storage/redis/redis-master.yaml

  
    - staging/storage/redis/redis-sentinel-controller.yaml

  
    - staging/storage/redis/redis-sentinel-service.yaml

  
    - staging/storage/rethinkdb/admin-pod.yaml

  
    - staging/storage/rethinkdb/admin-service.yaml

  
    - staging/storage/rethinkdb/driver-service.yaml

  
    - staging/storage/rethinkdb/rc.yaml

  
    - staging/storage/vitess/guestbook-controller.yaml

  
    - staging/storage/vitess/guestbook-service.yaml

  
    - staging/storage/vitess/vtctld-service.yaml

  
    - staging/storage/vitess/vtgate-service.yaml

  
    - staging/storm/storm-worker-controller.yaml

  
    - staging/sysdig-cloud/sysdig-daemonset.yaml

  
    - staging/sysdig-cloud/sysdig-rc.yaml

  
    - staging/volumes/aws_ebs/aws-ebs-web.yaml

  
    - staging/volumes/azure_disk/azure.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/account-specified-hdd/pod-uses-account-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/account-specified-hdd/pvc-on-account-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/account-specified-hdd/storageclass-account-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/dedicated-hdd/pod-uses-dedicated-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/dedicated-hdd/pvc-on-dedicated-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/dedicated-hdd/storageclass-dedicated-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-hdd/pod-uses-shared-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-hdd/pvc-on-shared-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-hdd/storageclass-shared-hdd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-ssd/pod-uses-shared-ssd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-ssd/pvc-on-shared-ssd.yaml

  
    - staging/volumes/azure_disk/claim/blob-based-disk/shared-ssd/storageclass-shared-ssd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-hdd/pod-uses-managed-hdd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-hdd/pvc-on-managed-hdd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-hdd/storageclass-managed-hdd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-ssd/pod-uses-managed-ssd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-ssd/pvc-on-managed-ssd.yaml

  
    - staging/volumes/azure_disk/claim/managed-disk/managed-ssd/storageclass-managed-ssd.yaml

  
    - staging/volumes/azure_disk/static-provisioning/managed-disk/pod-uses-existing-managed-disk.yaml

  
    - staging/volumes/azure_file/azure-2.yaml

  
    - staging/volumes/azure_file/azure-pv.yaml

  
    - staging/volumes/azure_file/azure-pvc.yaml

  
    - staging/volumes/azure_file/azure.yaml

  
    - staging/volumes/azure_file/secret/azure-secret.yaml

  
    - staging/volumes/cinder/cinder-web.yaml

  
    - staging/volumes/fibre_channel/fc.yaml

  
    - staging/volumes/flexvolume/deploy/ds.yaml

  
    - staging/volumes/flexvolume/nginx-dummy-attachable.yaml

  
    - staging/volumes/flexvolume/nginx-dummy.yaml

  
    - staging/volumes/flexvolume/nginx-lvm.yaml

  
    - staging/volumes/flexvolume/nginx-nfs.yaml

  
    - staging/volumes/flexvolume/nginx.yaml

  
    - staging/volumes/flocker/flocker-pod-with-rc.yml

  
    - staging/volumes/flocker/flocker-pod.yml

  
    - staging/volumes/nfs/nfs-busybox-deployment.yaml

  
    - staging/volumes/nfs/nfs-pv.yaml

  
    - staging/volumes/nfs/nfs-pvc.yaml

  
    - staging/volumes/nfs/nfs-server-deployment.yaml

  
    - staging/volumes/nfs/nfs-server-service.yaml

  
    - staging/volumes/nfs/nfs-web-deployment.yaml

  
    - staging/volumes/nfs/nfs-web-service.yaml

  
    - staging/volumes/nfs/provisioner/nfs-server-azure-pv.yaml

  
    - staging/volumes/nfs/provisioner/nfs-server-cdk-pv.yaml

  
    - staging/volumes/nfs/provisioner/nfs-server-gce-pv.yaml

  
    - staging/volumes/portworx/portworx-volume-pod.yaml

  
    - staging/volumes/portworx/portworx-volume-pv.yaml

  
    - staging/volumes/portworx/portworx-volume-pvc.yaml

  
    - staging/volumes/portworx/portworx-volume-pvcpod.yaml

  
    - staging/volumes/portworx/portworx-volume-pvcsc.yaml

  
    - staging/volumes/portworx/portworx-volume-pvcscpod.yaml

  
    - staging/volumes/portworx/portworx-volume-sc-high.yaml

  
    - staging/volumes/quobyte/quobyte-pod.yaml

  
    - staging/volumes/scaleio/pod-sc-pvc.yaml

  
    - staging/volumes/scaleio/pod.yaml

  
    - staging/volumes/scaleio/sc-pvc.yaml

  
    - staging/volumes/scaleio/sc.yaml

  
    - staging/volumes/scaleio/secret.yaml

  
    - staging/volumes/vsphere/deployment.yaml

  
    - staging/volumes/vsphere/simple-statefulset.yaml

  
    - staging/volumes/vsphere/simple-storageclass.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pod.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pv.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pvc.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pvcpod.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pvcsc.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pvcscpod.yaml

  
    - staging/volumes/vsphere/vsphere-volume-pvcscvsanpod.yaml

  
    - staging/volumes/vsphere/vsphere-volume-sc-fast.yaml

  
    - staging/volumes/vsphere/vsphere-volume-sc-vsancapabilities-with-datastore.yaml

  
    - staging/volumes/vsphere/vsphere-volume-sc-vsancapabilities.yaml

  
    - staging/volumes/vsphere/vsphere-volume-sc-with-datastore.yaml

  
    - staging/volumes/vsphere/vsphere-volume-spbm-policy-with-datastore.yaml

  
    - staging/volumes/vsphere/vsphere-volume-spbm-policy.yaml

  
    - volumes/cephfs/cephfs-with-secret.yaml

  
    - volumes/cephfs/cephfs.yaml

  
    - volumes/cephfs/secret/ceph-secret.yaml

  
    - volumes/glusterfs/glusterfs-endpoints.yaml

  
    - volumes/glusterfs/glusterfs-pod.yaml

  
    - volumes/glusterfs/glusterfs-service.yaml

  
    - volumes/iscsi/chap-secret.yaml

  
    - volumes/iscsi/iscsi-chap.yaml

  
    - volumes/iscsi/iscsi.yaml

  
    - volumes/rbd/rbd-with-secret.yaml

  
    - volumes/rbd/rbd.yaml

  
    - volumes/rbd/secret/ceph-secret.yaml

  
    - volumes/storageos/storageos-pod.yaml

  
    - volumes/storageos/storageos-pv.yaml

  
    - volumes/storageos/storageos-pvc.yaml

  
    - volumes/storageos/storageos-pvcpod.yaml

  
    - volumes/storageos/storageos-sc-pvc.yaml

  
    - volumes/storageos/storageos-sc-pvcpod.yaml

  
    - volumes/storageos/storageos-sc.yaml

  
    - volumes/storageos/storageos-secret.yaml

[_Created by Sourcegraph batch change `bolaji.olajide/demo-7-jul`._](https://demo.sourcegraph.com/users/bolaji.olajide/batch-changes/demo-7-jul)